### PR TITLE
Add overlap-based audio verification to the test harness

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -73,24 +73,24 @@ The Makefile handles building the bridge image, the inferno2pipe image (with sub
 Seven Docker containers on a shared bridge network (single-stream test):
 
 ```
-┌──────────────┐  ┌──────────────────┐  ┌───────────────┐
-│ clock_source │  │ sendspin_source   │  │ control_and_  │
-│ (usrvclock)  │  │ (Python sendspin) │  │ test          │
-│ PTP clock    │  │ 1kHz sine WAV    │  │ (netaudio +   │
-│ for all      │  │ served via WS    │  │  signal check)│
-└──────┬───────┘  └────────┬─────────┘  └───────┬───────┘
-       │                   │ WebSocket           │ netaudio
-       │    ┌──────────────▼───────────┐         │ subscription
-       ├───→│     bridge               │         │
-       │    │  (spin2dante)       │◄────────┘
-       │    │  DANTE TX: "SSBridge"    │
-       │    └──────────────┬───────────┘
-       │                   │ DANTE multicast UDP
-       │    ┌──────────────▼───────────┐
-       └───→│     i2pipe               │
-            │  (inferno2pipe)          │
-            │  captures to .raw file   │
-            └──────────────────────────┘
+┌──────────────┐  ┌──────────────┐  ┌──────────────────┐  ┌───────────────┐
+│ ptp-master   │  │ ptp-follower │  │ sendspin_source   │  │ control_and_  │
+│ (PTPv2 ref)  │→ │ usrvclock     │  │ deterministic     │  │ test          │
+│              │  │ exporter      │  │ 24-bit reference  │  │ (netaudio +   │
+└──────────────┘  └──────┬───────┘  │ WAV via WS        │  │ overlap check)│
+                         │          └────────┬─────────┘  └───────┬───────┘
+                         │                   │ WebSocket           │ netaudio
+                         │    ┌──────────────▼───────────┐         │ subscription
+                         ├───→│     bridge               │         │
+                         │    │  (spin2dante)            │◄────────┘
+                         │    │  DANTE TX: "SSBridge"    │
+                         │    └──────────────┬───────────┘
+                         │                   │ DANTE multicast UDP
+                         │    ┌──────────────▼───────────┐
+                         └───→│     i2pipe               │
+                              │  (inferno2pipe)          │
+                              │  captures to .raw file   │
+                              └──────────────────────────┘
 ```
 
 ### Container Details
@@ -100,7 +100,7 @@ Seven Docker containers on a shared bridge network (single-stream test):
 | `init` | `alpine:3` | Clears the shared volume before each run |
 | `ptp-master` | Built from `statime/` | PTPv2 clock master (reference clock) |
 | `ptp-follower` | Built from `statime/` | PTPv2 clock follower — syncs to master, exports usrvclock |
-| `sendspin_source` | `python:3.13-alpine` + `pip install sendspin` | Generates a 30s 1kHz sine WAV, serves it via `sendspin serve` on port 8927 |
+| `sendspin_source` | `python:3.13-alpine` + `pip install sendspin` | Generates a deterministic 30s 24-bit stereo reference WAV and matching capture-domain raw reference, serves the WAV via `sendspin serve` on port 8927 |
 | `bridge` | Built from this repo's `Dockerfile` | The bridge under test. Connects to sendspin_source, transmits as DANTE device "SSBridge" |
 | `i2pipe` | `inferno_aoip:alpine-i2pipe` (pre-built) | DANTE receiver. Captures audio to `/shared/capture.raw` |
 | `control_and_test` | `python:3.13-alpine` + `netaudio` | Orchestrator: discovers DANTE devices, creates subscriptions, validates captured audio |
@@ -109,7 +109,7 @@ Seven Docker containers on a shared bridge network (single-stream test):
 
 The Statime PTP follower exports clock overlays via Unix datagram sockets (usrvclock protocol). The server creates a socket at `/shared/usrvclock`. Each client (bridge, i2pipe) creates a response socket in `$TMPDIR`. The server sends clock overlays back to these client sockets.
 
-**The client TMPDIR must be on the shared Docker volume.** If TMPDIR is `/tmp` (container-local), the clock_source container can't reach the client sockets and you get:
+**The client TMPDIR must be on the shared Docker volume.** If TMPDIR is `/tmp` (container-local), the PTP follower container can't reach the client sockets and you get:
 
 ```
 ptp-follower  | sendto failed: No such file or directory
@@ -126,8 +126,6 @@ bridge:
   entrypoint: ["/bin/sh", "-c"]
   command: ["mkdir -p /shared/tmp_bridge && exec spin2dante ..."]
 ```
-
-The clock_source also needs `USRVCLOCK_SOCKET=/shared/usrvclock` set explicitly.
 
 ## Critical: inferno2pipe Image Must Be Pre-Built
 
@@ -149,7 +147,7 @@ failed to read `/build/searchfire/Cargo.toml`: No such file or directory
 
 The containers start in dependency order, but some take time to initialize:
 
-1. **sendspin_source** (~5-10s): generates 30s WAV test tone, starts sendspin server (pip install happens at image build time)
+1. **sendspin_source** (~5-10s): generates the deterministic reference WAV + `/shared/reference_capture.raw`, then starts sendspin server (pip install happens at image build time)
 2. **bridge** retries connection every 2s until sendspin_source is ready
 3. **i2pipe** sleeps 5s before starting (gives bridge time to register as DANTE device)
 4. **FlowsTransmitter** may log "clock unavailable" for ~10-20s until it receives its first PTP overlay
@@ -194,7 +192,7 @@ bridge  | starting FlowsTransmitter (start_time=0)
 bridge  | prebuffer complete (2400 samples written), fill=..., now transmitting
 bridge  | [buffer] fill=... target=2400 ...
 
-control_and_test | Signal present: YES
+control_and_test | [capture.raw] bit-perfect overlap found
 control_and_test | Capture file size OK
 ```
 
@@ -202,9 +200,9 @@ control_and_test | Capture file size OK
 ```
 bridge  | clock unavailable, can't transmit     # Normal at startup, bad if persistent
 bridge  | rejecting stream: ...                  # Format mismatch
-clock_source | sendto failed                     # TMPDIR not on shared volume
+ptp-follower | sendto failed                     # TMPDIR not on shared volume
 control_and_test | TIMEOUT: devices not found    # Network or startup issue
-control_and_test | Signal present: NO            # Audio not flowing
+control_and_test | no exact alignment window found  # audio missing or corrupted
 ```
 
 ### Capture file format
@@ -232,7 +230,7 @@ Useful for debugging when `docker compose up` doesn't give you enough control:
 cd test
 
 # 1. Start infrastructure
-docker compose up -d init clock_source sendspin_source
+docker compose up -d init ptp-master ptp-follower sendspin_source
 
 # 2. Wait for sendspin to be ready (~20s)
 sleep 20
@@ -275,33 +273,33 @@ The `--build` flag rebuilds changed images. The bridge Dockerfile doesn't cache 
 
 ## Multi-Stream Test (`make test-multi`)
 
-Tests 4 bridge instances all connected to the same Sendspin server, simulating a real multi-room deployment where all zones play the same stream in sync.
+Tests 16 bridge instances all connected to the same Sendspin server, simulating a real multi-room deployment where all zones play the same stream in sync.
 
 ### What it does
 
-- 1 Sendspin server serving a 1kHz test tone
-- 4 bridge containers (SS01–SS04), each a separate DANTE TX device
-- 4 i2pipe containers (rx01–rx04), each capturing one bridge's output
-- 1 control container that creates all 8 subscriptions and analyzes results
+- 1 Sendspin server serving the deterministic reference signal
+- 16 bridge containers (SS01–SS16), each a separate DANTE TX device
+- 16 i2pipe containers (rx01–rx16), each capturing one bridge's output
+- 1 control container that creates all 32 subscriptions and analyzes results
 
 ### What it measures
 
-1. **Signal presence**: Each of the 4 captures is checked for non-zero audio
-2. **Cross-stream sync**: Compares the onset (first non-zero sample) across all 4 captures and reports the spread in samples and milliseconds
+1. **Bit-perfect overlap**: Each capture is aligned against the shared reference signal and must contain one continuous exact match region
+2. **Cross-stream sync**: Compares the source-alignment offsets across all captures and reports the spread in samples and milliseconds
 
 ```
-Onset spread: 48 samples (1.00ms)
-SYNC: GOOD (spread < 10ms)
+Source-offset spread: 24 frames (0.50ms)
+SYNC: GOOD (spread < 1ms)
 ```
 
 Sync quality thresholds:
-- **GOOD**: < 10ms spread (< 480 samples)
-- **FAIR**: < 100ms spread
-- **POOR**: >= 100ms spread
+- **GOOD**: < 1ms spread (< 48 samples)
+- **FAIR**: < 10ms spread (< 480 samples)
+- **POOR**: >= 10ms spread
 
 ### Resource requirements
 
-35 containers total (16 bridges + 16 receivers + clock + source + control). Each inferno DeviceServer uses a real-time thread. Expect:
+37 containers total (16 bridges + 16 receivers + init + ptp-master + ptp-follower + source + control). Each inferno DeviceServer uses a real-time thread. Expect:
 - ~2-3GB RAM
 - Significant CPU during startup (all containers building/initializing in parallel)
 - ~3-4 minutes total runtime (builds + discovery timeout + 20s recording)
@@ -371,8 +369,8 @@ Tested and validated via `make test-resilience`:
 
 ## Known Limitations
 
-- **No automated pass/fail**: The test checks signal presence but doesn't verify bit-perfect output or exact waveform shape. WavDiff comparison is planned.
+- **Bit-perfect over overlap, not full-boundary perfection**: The automated check allows an unknown dropped prefix/suffix. It proves the received overlap matches exactly, but it does not require sample 0 of the source to be present.
 - **Sendspin source codec**: The `sendspin serve` command decides the codec. With a local WAV file it typically sends PCM, but behavior may vary by version.
 - **PTP clock warmup**: 10-15s of "clock unavailable" is normal while the Statime follower syncs to the master. The bridge auto-realigns once the clock becomes available.
-- **Single-run test audio**: The 30s test tone loops only if sendspin loops it. After 30s, the stream may end.
+- **Single-run test audio**: The 30s deterministic reference loops only if sendspin loops it. After 30s, the stream may end.
 - **FLAC not testable**: sendspin-rs v0.1 only has a PCM decoder. FLAC testing requires either a newer sendspin-rs or a custom decoder.

--- a/test/common/audio_compare.py
+++ b/test/common/audio_compare.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+
+
+def find_alignment(reference: bytes, capture: bytes, frame_bytes: int, window_frames: int, probe_frames: int):
+    capture_frames = len(capture) // frame_bytes
+    reference_frames = len(reference) // frame_bytes
+    max_start = min(max(capture_frames - window_frames, 0), probe_frames)
+    zero_window = b"\x00" * (window_frames * frame_bytes)
+
+    for capture_start in range(max_start + 1):
+        start_byte = capture_start * frame_bytes
+        end_byte = start_byte + window_frames * frame_bytes
+        window = capture[start_byte:end_byte]
+        if len(window) < window_frames * frame_bytes or window == zero_window or not any(window):
+            continue
+
+        ref_byte = reference.find(window)
+        while ref_byte != -1 and (ref_byte % frame_bytes) != 0:
+            ref_byte = reference.find(window, ref_byte + 1)
+        if ref_byte != -1:
+            return capture_start, ref_byte // frame_bytes
+
+    return None, None
+
+
+def analyze(reference: bytes, capture: bytes, sample_rate: int, channels: int, min_run_seconds: float):
+    frame_bytes = channels * 4
+    if len(reference) < frame_bytes or len(capture) < frame_bytes:
+        return {
+            "alignment_found": False,
+            "pass": False,
+            "reason": "reference or capture too small",
+        }
+
+    capture_start, reference_start = find_alignment(
+        reference=reference,
+        capture=capture,
+        frame_bytes=frame_bytes,
+        window_frames=64,
+        probe_frames=sample_rate * 10,
+    )
+    if capture_start is None:
+        return {
+            "alignment_found": False,
+            "pass": False,
+            "reason": "no exact alignment window found",
+        }
+
+    offset_frames = reference_start - capture_start
+    capture_first = max(0, -offset_frames)
+    reference_first = max(0, offset_frames)
+    capture_frames = len(capture) // frame_bytes
+    reference_frames = len(reference) // frame_bytes
+    overlap_frames = min(capture_frames - capture_first, reference_frames - reference_first)
+
+    longest_start = None
+    longest_len = 0
+    run_start = None
+    run_len = 0
+    matched_frames = 0
+    run_count = 0
+
+    for i in range(overlap_frames):
+        c0 = (capture_first + i) * frame_bytes
+        r0 = (reference_first + i) * frame_bytes
+        exact = capture[c0:c0 + frame_bytes] == reference[r0:r0 + frame_bytes]
+        if exact:
+            matched_frames += 1
+            if run_start is None:
+                run_start = i
+                run_len = 1
+                run_count += 1
+            else:
+                run_len += 1
+            if run_len > longest_len:
+                longest_len = run_len
+                longest_start = run_start
+        else:
+            run_start = None
+            run_len = 0
+
+    min_run_frames = int(min_run_seconds * sample_rate)
+    longest_end = None if longest_start is None else longest_start + longest_len
+    single_contiguous_match = matched_frames == longest_len
+
+    result = {
+        "alignment_found": True,
+        "offset_frames": offset_frames,
+        "offset_ms": offset_frames * 1000.0 / sample_rate,
+        "capture_probe_start_frame": capture_start,
+        "reference_probe_start_frame": reference_start,
+        "capture_frames": capture_frames,
+        "reference_frames": reference_frames,
+        "overlap_frames": overlap_frames,
+        "matched_frames": matched_frames,
+        "match_ratio": (matched_frames / overlap_frames) if overlap_frames else 0.0,
+        "run_count": run_count,
+        "longest_run_frames": longest_len,
+        "longest_run_seconds": longest_len / sample_rate,
+        "longest_run_start_frame": longest_start,
+        "longest_run_end_frame": longest_end,
+        "single_contiguous_match": single_contiguous_match,
+    }
+
+    if longest_len < min_run_frames:
+        result["pass"] = False
+        result["reason"] = f"longest exact run too short ({longest_len} frames)"
+    elif not single_contiguous_match:
+        result["pass"] = False
+        result["reason"] = "exact matches split into multiple runs"
+    else:
+        result["pass"] = True
+        result["reason"] = "bit-perfect overlap found"
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare capture against deterministic reference")
+    parser.add_argument("--reference", required=True)
+    parser.add_argument("--capture", required=True)
+    parser.add_argument("--label", default="capture")
+    parser.add_argument("--sample-rate", type=int, default=48000)
+    parser.add_argument("--channels", type=int, default=2)
+    parser.add_argument("--min-run-seconds", type=float, default=5.0)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    with open(args.reference, "rb") as ref_file:
+        reference = ref_file.read()
+    with open(args.capture, "rb") as capture_file:
+        capture = capture_file.read()
+
+    result = analyze(reference, capture, args.sample_rate, args.channels, args.min_run_seconds)
+    result["label"] = args.label
+
+    if args.json:
+        json.dump(result, sys.stdout)
+        sys.stdout.write("\n")
+    else:
+        print(f"[{args.label}] alignment_found={result['alignment_found']}")
+        if result["alignment_found"]:
+            print(
+                f"[{args.label}] offset={result['offset_frames']} frames ({result['offset_ms']:+.2f}ms), "
+                f"longest_run={result['longest_run_frames']} frames ({result['longest_run_seconds']:.2f}s), "
+                f"run_count={result['run_count']}, match_ratio={result['match_ratio']:.3f}"
+            )
+        print(f"[{args.label}] {result['reason']}")
+
+    return 0 if result["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/common/audio_compare.py
+++ b/test/common/audio_compare.py
@@ -6,16 +6,42 @@ import sys
 
 def find_alignment(reference: bytes, capture: bytes, frame_bytes: int, window_frames: int, probe_frames: int):
     capture_frames = len(capture) // frame_bytes
-    reference_frames = len(reference) // frame_bytes
     max_start = min(max(capture_frames - window_frames, 0), probe_frames)
-    zero_window = b"\x00" * (window_frames * frame_bytes)
 
+    first_nonzero = None
     for capture_start in range(max_start + 1):
+        start_byte = capture_start * frame_bytes
+        frame = capture[start_byte:start_byte + frame_bytes]
+        if len(frame) < frame_bytes or not any(frame):
+            continue
+        first_nonzero = capture_start
+        break
+
+    if first_nonzero is None:
+        return None, None
+
+    search_end = min(max_start, first_nonzero + 4096)
+    for capture_start in range(first_nonzero, search_end + 1, 16):
         start_byte = capture_start * frame_bytes
         end_byte = start_byte + window_frames * frame_bytes
         window = capture[start_byte:end_byte]
-        if len(window) < window_frames * frame_bytes or window == zero_window or not any(window):
+        if len(window) < window_frames * frame_bytes:
+            break
+
+        ref_byte = reference.find(window)
+        while ref_byte != -1 and (ref_byte % frame_bytes) != 0:
+            ref_byte = reference.find(window, ref_byte + 1)
+        if ref_byte != -1:
+            return capture_start, ref_byte // frame_bytes
+
+    for capture_start in range(first_nonzero, search_end + 1):
+        if (capture_start - first_nonzero) % 16 == 0:
             continue
+        start_byte = capture_start * frame_bytes
+        end_byte = start_byte + window_frames * frame_bytes
+        window = capture[start_byte:end_byte]
+        if len(window) < window_frames * frame_bytes:
+            break
 
         ref_byte = reference.find(window)
         while ref_byte != -1 and (ref_byte % frame_bytes) != 0:
@@ -49,42 +75,26 @@ def analyze(reference: bytes, capture: bytes, sample_rate: int, channels: int, m
             "reason": "no exact alignment window found",
         }
 
-    offset_frames = reference_start - capture_start
-    capture_first = max(0, -offset_frames)
-    reference_first = max(0, offset_frames)
     capture_frames = len(capture) // frame_bytes
     reference_frames = len(reference) // frame_bytes
+    offset_frames = reference_start - capture_start
+    capture_first = capture_start
+    reference_first = reference_start
     overlap_frames = min(capture_frames - capture_first, reference_frames - reference_first)
-
-    longest_start = None
-    longest_len = 0
-    run_start = None
-    run_len = 0
-    matched_frames = 0
-    run_count = 0
-
-    for i in range(overlap_frames):
-        c0 = (capture_first + i) * frame_bytes
-        r0 = (reference_first + i) * frame_bytes
-        exact = capture[c0:c0 + frame_bytes] == reference[r0:r0 + frame_bytes]
-        if exact:
-            matched_frames += 1
-            if run_start is None:
-                run_start = i
-                run_len = 1
-                run_count += 1
-            else:
-                run_len += 1
-            if run_len > longest_len:
-                longest_len = run_len
-                longest_start = run_start
-        else:
-            run_start = None
-            run_len = 0
+    if overlap_frames <= 0:
+        return {
+            "alignment_found": False,
+            "pass": False,
+            "reason": "no overlapping frames after alignment",
+        }
 
     min_run_frames = int(min_run_seconds * sample_rate)
-    longest_end = None if longest_start is None else longest_start + longest_len
-    single_contiguous_match = matched_frames == longest_len
+    overlap_bytes = overlap_frames * frame_bytes
+    ref_overlap = reference[reference_first * frame_bytes:(reference_first * frame_bytes) + overlap_bytes]
+    cap_overlap = capture[capture_first * frame_bytes:(capture_first * frame_bytes) + overlap_bytes]
+    exact_overlap = ref_overlap == cap_overlap
+
+    matched_frames = overlap_frames if exact_overlap else 0
 
     result = {
         "alignment_found": True,
@@ -97,20 +107,20 @@ def analyze(reference: bytes, capture: bytes, sample_rate: int, channels: int, m
         "overlap_frames": overlap_frames,
         "matched_frames": matched_frames,
         "match_ratio": (matched_frames / overlap_frames) if overlap_frames else 0.0,
-        "run_count": run_count,
-        "longest_run_frames": longest_len,
-        "longest_run_seconds": longest_len / sample_rate,
-        "longest_run_start_frame": longest_start,
-        "longest_run_end_frame": longest_end,
-        "single_contiguous_match": single_contiguous_match,
+        "run_count": 1 if exact_overlap else 0,
+        "longest_run_frames": overlap_frames if exact_overlap else 0,
+        "longest_run_seconds": overlap_frames / sample_rate if exact_overlap else 0.0,
+        "longest_run_start_frame": 0 if exact_overlap else None,
+        "longest_run_end_frame": overlap_frames if exact_overlap else None,
+        "single_contiguous_match": exact_overlap,
     }
 
-    if longest_len < min_run_frames:
+    if overlap_frames < min_run_frames:
         result["pass"] = False
-        result["reason"] = f"longest exact run too short ({longest_len} frames)"
-    elif not single_contiguous_match:
+        result["reason"] = f"overlap too short ({overlap_frames} frames)"
+    elif not exact_overlap:
         result["pass"] = False
-        result["reason"] = "exact matches split into multiple runs"
+        result["reason"] = "overlap differs from reference"
     else:
         result["pass"] = True
         result["reason"] = "bit-perfect overlap found"

--- a/test/common/audio_compare.py
+++ b/test/common/audio_compare.py
@@ -4,15 +4,61 @@ import json
 import sys
 
 
+def is_nonzero_frame(capture: bytes, frame_start: int, frame_bytes: int) -> bool:
+    start_byte = frame_start * frame_bytes
+    frame = capture[start_byte:start_byte + frame_bytes]
+    return len(frame) == frame_bytes and any(frame)
+
+
+def try_match_window(reference: bytes, capture: bytes, frame_bytes: int, capture_start: int, window_frames: int):
+    start_byte = capture_start * frame_bytes
+    end_byte = start_byte + window_frames * frame_bytes
+    window = capture[start_byte:end_byte]
+    if len(window) < window_frames * frame_bytes:
+        return None
+
+    ref_byte = reference.find(window)
+    while ref_byte != -1 and (ref_byte % frame_bytes) != 0:
+        ref_byte = reference.find(window, ref_byte + 1)
+    if ref_byte != -1:
+        return capture_start, ref_byte // frame_bytes
+
+    return None
+
+
+def iter_candidate_starts(first_nonzero: int, max_start: int):
+    yielded = set()
+
+    # Search densely around the first audible region to keep the common case fast.
+    local_end = min(max_start, first_nonzero + 4096)
+    for step in (16, 1):
+        for capture_start in range(first_nonzero, local_end + 1, step):
+            if capture_start not in yielded:
+                yielded.add(capture_start)
+                yield capture_start
+
+    # If startup garbage exists before valid aligned audio, probe deeper into the capture
+    # at wider intervals so we can still find a later exact window without scanning every frame.
+    for step, limit in (
+        (256, min(max_start, first_nonzero + 65536)),
+        (1024, max_start),
+    ):
+        start = local_end + 1
+        if start > limit:
+            continue
+        for capture_start in range(start, limit + 1, step):
+            if capture_start not in yielded:
+                yielded.add(capture_start)
+                yield capture_start
+
+
 def find_alignment(reference: bytes, capture: bytes, frame_bytes: int, window_frames: int, probe_frames: int):
     capture_frames = len(capture) // frame_bytes
     max_start = min(max(capture_frames - window_frames, 0), probe_frames)
 
     first_nonzero = None
     for capture_start in range(max_start + 1):
-        start_byte = capture_start * frame_bytes
-        frame = capture[start_byte:start_byte + frame_bytes]
-        if len(frame) < frame_bytes or not any(frame):
+        if not is_nonzero_frame(capture, capture_start, frame_bytes):
             continue
         first_nonzero = capture_start
         break
@@ -20,39 +66,24 @@ def find_alignment(reference: bytes, capture: bytes, frame_bytes: int, window_fr
     if first_nonzero is None:
         return None, None
 
-    search_end = min(max_start, first_nonzero + 4096)
-    for capture_start in range(first_nonzero, search_end + 1, 16):
-        start_byte = capture_start * frame_bytes
-        end_byte = start_byte + window_frames * frame_bytes
-        window = capture[start_byte:end_byte]
-        if len(window) < window_frames * frame_bytes:
-            break
-
-        ref_byte = reference.find(window)
-        while ref_byte != -1 and (ref_byte % frame_bytes) != 0:
-            ref_byte = reference.find(window, ref_byte + 1)
-        if ref_byte != -1:
-            return capture_start, ref_byte // frame_bytes
-
-    for capture_start in range(first_nonzero, search_end + 1):
-        if (capture_start - first_nonzero) % 16 == 0:
+    for capture_start in iter_candidate_starts(first_nonzero, max_start):
+        if not is_nonzero_frame(capture, capture_start, frame_bytes):
             continue
-        start_byte = capture_start * frame_bytes
-        end_byte = start_byte + window_frames * frame_bytes
-        window = capture[start_byte:end_byte]
-        if len(window) < window_frames * frame_bytes:
-            break
-
-        ref_byte = reference.find(window)
-        while ref_byte != -1 and (ref_byte % frame_bytes) != 0:
-            ref_byte = reference.find(window, ref_byte + 1)
-        if ref_byte != -1:
-            return capture_start, ref_byte // frame_bytes
+        match = try_match_window(reference, capture, frame_bytes, capture_start, window_frames)
+        if match is not None:
+            return match
 
     return None, None
 
 
-def analyze(reference: bytes, capture: bytes, sample_rate: int, channels: int, min_run_seconds: float):
+def analyze(
+    reference: bytes,
+    capture: bytes,
+    sample_rate: int,
+    channels: int,
+    min_run_seconds: float,
+    probe_seconds: float,
+):
     frame_bytes = channels * 4
     if len(reference) < frame_bytes or len(capture) < frame_bytes:
         return {
@@ -66,7 +97,7 @@ def analyze(reference: bytes, capture: bytes, sample_rate: int, channels: int, m
         capture=capture,
         frame_bytes=frame_bytes,
         window_frames=64,
-        probe_frames=sample_rate * 10,
+        probe_frames=int(sample_rate * probe_seconds),
     )
     if capture_start is None:
         return {
@@ -136,6 +167,7 @@ def main() -> int:
     parser.add_argument("--sample-rate", type=int, default=48000)
     parser.add_argument("--channels", type=int, default=2)
     parser.add_argument("--min-run-seconds", type=float, default=5.0)
+    parser.add_argument("--probe-seconds", type=float, default=30.0)
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 
@@ -144,7 +176,14 @@ def main() -> int:
     with open(args.capture, "rb") as capture_file:
         capture = capture_file.read()
 
-    result = analyze(reference, capture, args.sample_rate, args.channels, args.min_run_seconds)
+    result = analyze(
+        reference,
+        capture,
+        args.sample_rate,
+        args.channels,
+        args.min_run_seconds,
+        args.probe_seconds,
+    )
     result["label"] = args.label
 
     if args.json:

--- a/test/common/generate_reference_signal.py
+++ b/test/common/generate_reference_signal.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import argparse
+import struct
+import wave
+
+
+def xorshift32(state: int) -> int:
+    state &= 0xFFFFFFFF
+    state ^= (state << 13) & 0xFFFFFFFF
+    state ^= (state >> 17) & 0xFFFFFFFF
+    state ^= (state << 5) & 0xFFFFFFFF
+    return state & 0xFFFFFFFF
+
+
+def to_signed_24(state: int) -> int:
+    sample = (state >> 8) & 0xFFFFFF
+    if sample >= 0x800000:
+        sample -= 0x1000000
+    return sample
+
+
+def pack_s24le(sample: int) -> bytes:
+    sample &= 0xFFFFFF
+    return bytes((sample & 0xFF, (sample >> 8) & 0xFF, (sample >> 16) & 0xFF))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate deterministic reference WAV + capture-domain raw")
+    parser.add_argument("--wav-path", required=True)
+    parser.add_argument("--capture-raw-path", required=True)
+    parser.add_argument("--duration", type=int, default=30)
+    parser.add_argument("--sample-rate", type=int, default=48000)
+    args = parser.parse_args()
+
+    left_state = 0x13579BDF
+    right_state = 0x2468ACE1
+    total_frames = args.duration * args.sample_rate
+
+    with wave.open(args.wav_path, "wb") as wav_file, open(args.capture_raw_path, "wb") as raw_file:
+        wav_file.setnchannels(2)
+        wav_file.setsampwidth(3)
+        wav_file.setframerate(args.sample_rate)
+
+        for _ in range(total_frames):
+            left_state = xorshift32(left_state)
+            right_state = xorshift32(right_state)
+
+            left_sample = to_signed_24(left_state)
+            right_sample = to_signed_24(right_state)
+
+            wav_file.writeframesraw(pack_s24le(left_sample) + pack_s24le(right_sample))
+            raw_file.write(struct.pack("<i", left_sample << 8))
+            raw_file.write(struct.pack("<i", right_sample << 8))
+
+    print(
+        f"Generated deterministic reference: {args.duration}s, {args.sample_rate}Hz, 24-bit stereo PRBS"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/control_and_test/Dockerfile
+++ b/test/control_and_test/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.13-alpine
 RUN apk add --no-cache sox build-base git linux-headers
 RUN pip install --no-cache-dir netaudio
-COPY control_and_test.sh /control_and_test.sh
+COPY control_and_test/control_and_test.sh /control_and_test.sh
+COPY common/audio_compare.py /audio_compare.py
 RUN chmod +x /control_and_test.sh
 ENTRYPOINT ["/control_and_test.sh"]

--- a/test/control_and_test/control_and_test.sh
+++ b/test/control_and_test/control_and_test.sh
@@ -52,9 +52,11 @@ sleep 20
 
 echo ""
 echo "=== Checking capture file ==="
-if [ -f /shared/capture.raw ]; then
+if [ -f /shared/capture.raw ] && [ -f /shared/reference_capture.raw ]; then
     size=$(stat -c %s /shared/capture.raw 2>/dev/null || stat -f %z /shared/capture.raw)
+    ref_size=$(stat -c %s /shared/reference_capture.raw 2>/dev/null || stat -f %z /shared/reference_capture.raw)
     echo "Capture file size: $size bytes"
+    echo "Reference file size: $ref_size bytes"
 
     min_size=$((5 * 48000 * 2 * 4))
     if [ "$size" -lt "$min_size" ]; then
@@ -64,33 +66,16 @@ if [ -f /shared/capture.raw ]; then
     fi
 
     echo ""
-    echo "=== Signal analysis ==="
-    python3 -c "
-import struct, math
-
-with open('/shared/capture.raw', 'rb') as f:
-    data = f.read()
-
-samples = len(data) // 4
-nonzero = 0
-peak = 0
-for i in range(min(samples, 480000)):
-    val = struct.unpack_from('<i', data, i * 4)[0]
-    if val != 0:
-        nonzero += 1
-    peak = max(peak, abs(val))
-
-print(f'Total samples: {samples}')
-print(f'Non-zero samples (first 10s): {nonzero}/{min(samples, 480000)}')
-if peak > 0:
-    print(f'Peak value: {peak} ({20 * math.log10(peak / 2147483647):.1f} dBFS)')
-else:
-    print('Peak: 0 (silence)')
-print(f'Signal present: {\"YES\" if nonzero > 1000 else \"NO\"}')
-" || echo "Signal analysis failed"
+    echo "=== Overlap comparison ==="
+    python3 /audio_compare.py \
+        --reference /shared/reference_capture.raw \
+        --capture /shared/capture.raw \
+        --label capture.raw \
+        --min-run-seconds 5
 
 else
-    echo "NOTE: no capture file yet (subscriptions may not have been established)"
+    echo "NOTE: capture or reference file missing"
+    exit 1
 fi
 
 echo ""

--- a/test/control_and_test_multi/Dockerfile
+++ b/test/control_and_test_multi/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.13-alpine
 RUN apk add --no-cache build-base git linux-headers
 RUN pip install --no-cache-dir netaudio
-COPY control_and_test_multi.sh /control_and_test_multi.sh
+COPY control_and_test_multi/control_and_test_multi.sh /control_and_test_multi.sh
+COPY common/audio_compare.py /audio_compare.py
 RUN chmod +x /control_and_test_multi.sh
 ENTRYPOINT ["/control_and_test_multi.sh"]

--- a/test/control_and_test_multi/control_and_test_multi.sh
+++ b/test/control_and_test_multi/control_and_test_multi.sh
@@ -3,6 +3,7 @@ set -e
 
 STREAM_COUNT=16
 RECORD_SECS=20
+COMPARE_JSON=/tmp/compare_results.jsonl
 
 echo "=== spin2dante Multi-Stream E2E Test (${STREAM_COUNT} streams) ==="
 echo "Waiting for all DANTE devices to appear..."
@@ -68,8 +69,9 @@ echo "=== Analyzing ${STREAM_COUNT} capture files ==="
 
 total=0
 ok=0
-signal_present=0
+bit_perfect=0
 min_size=$((5 * 48000 * 2 * 4))  # at least 5s of audio
+rm -f "$COMPARE_JSON"
 
 for i in $(seq 1 $STREAM_COUNT); do
     total=$((total + 1))
@@ -89,103 +91,79 @@ for i in $(seq 1 $STREAM_COUNT); do
 
     ok=$((ok + 1))
 
-    # Signal check — scan up to 30s into the file (audio may start late)
-    has_signal=$(python3 -c "
-import struct
-with open('$file', 'rb') as f:
-    data = f.read(48000 * 8 * 30)  # up to 30s of stereo 32-bit
-nonzero = sum(1 for i in range(0, len(data), 4) if struct.unpack_from('<i', data, i)[0] != 0)
-print('YES' if nonzero > 100 else 'NO')
-" 2>/dev/null || echo "ERR")
-
-    if [ "$has_signal" = "YES" ]; then
-        signal_present=$((signal_present + 1))
-        echo "  capture_${padded}.raw: ${size} bytes, signal=YES"
+    if python3 /audio_compare.py \
+        --reference /shared/reference_capture.raw \
+        --capture "$file" \
+        --label "capture_${padded}" \
+        --min-run-seconds 5 \
+        --json > /tmp/compare_${padded}.json
+    then
+        bit_perfect=$((bit_perfect + 1))
+        cat /tmp/compare_${padded}.json >> "$COMPARE_JSON"
+        echo "  capture_${padded}.raw: ${size} bytes, bit-perfect overlap=YES"
     else
-        echo "  capture_${padded}.raw: ${size} bytes, signal=${has_signal}"
+        cat /tmp/compare_${padded}.json >> "$COMPARE_JSON" 2>/dev/null || true
+        echo "  capture_${padded}.raw: ${size} bytes, bit-perfect overlap=NO"
     fi
 done
 
 echo ""
 echo "=== Cross-stream comparison ==="
-echo "Comparing captures pairwise to check synchronization..."
+echo "Comparing source offsets to check synchronization..."
 
-# Compare first capture to all others by looking for the 1kHz sine onset.
-# In a perfectly synchronized group, all captures should have nearly identical content.
 python3 -c "
-import struct, math
+import json
+from statistics import mean
 
-def read_samples(path, max_frames=48000*30):
-    \"\"\"Read left-channel samples as i32 values (up to 30s).\"\"\"
-    samples = []
-    try:
-        with open(path, 'rb') as f:
-            data = f.read(max_frames * 8)  # stereo 32-bit = 8 bytes/frame
-        for i in range(0, len(data), 8):  # step by frame (L+R)
-            if i + 4 <= len(data):
-                samples.append(struct.unpack_from('<i', data, i)[0])
-    except FileNotFoundError:
-        pass
-    return samples
+results = []
+try:
+    with open('$COMPARE_JSON', 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                results.append(json.loads(line))
+except FileNotFoundError:
+    pass
 
-def find_first_nonzero(samples, threshold=1000):
-    \"\"\"Find index of first sample above threshold.\"\"\"
-    for i, s in enumerate(samples):
-        if abs(s) > threshold:
-            return i
-    return -1
-
-def peak_of(samples):
-    if not samples:
-        return 0
-    return max(abs(s) for s in samples)
-
-ref_path = '/shared/capture_01.raw'
-ref = read_samples(ref_path)
-ref_onset = find_first_nonzero(ref)
-ref_peak = peak_of(ref)
-
-if not ref or ref_onset < 0:
-    print('Reference capture (01) has no signal, cannot compare.')
+if not results:
+    print('No successful overlap comparison results available.')
 else:
-    print(f'Reference (01): onset at sample {ref_onset}, peak={ref_peak}')
+    results.sort(key=lambda item: item['label'])
+    ref = results[0]
+    print(f\"Reference ({ref['label']}): offset={ref['offset_frames']} frames ({ref['offset_ms']:+.2f}ms)\")
     print()
-
     offsets = []
-    for i in range(2, $STREAM_COUNT + 1):
-        path = f'/shared/capture_{i:02d}.raw'
-        s = read_samples(path)
-        onset = find_first_nonzero(s)
-        peak = peak_of(s)
-
-        if onset < 0:
-            print(f'  capture_{i:02d}: no signal')
-        else:
-            offset = onset - ref_onset
-            offsets.append(offset)
-            offset_ms = offset / 48.0
-            print(f'  capture_{i:02d}: onset at {onset}, offset={offset:+d} samples ({offset_ms:+.2f}ms), peak={peak}')
+    for item in results[1:]:
+        relative = item['offset_frames'] - ref['offset_frames']
+        offsets.append(relative)
+        print(
+            f\"  {item['label']}: source offset={item['offset_frames']:+d} frames \"
+            f\"({item['offset_ms']:+.2f}ms), relative={relative:+d} frames ({relative/48.0:+.2f}ms), \"
+            f\"run={item['longest_run_seconds']:.2f}s\"
+        )
 
     if offsets:
         print()
-        min_off = min(offsets)
-        max_off = max(offsets)
-        spread = max_off - min_off
-        avg_off = sum(offsets) / len(offsets)
-        print(f'Onset spread: {spread} samples ({spread/48.0:.2f}ms)')
-        print(f'Min offset: {min_off:+d}, Max offset: {max_off:+d}, Avg: {avg_off:+.1f}')
-        if spread < 480:  # < 10ms
-            print('SYNC: GOOD (spread < 10ms)')
-        elif spread < 4800:  # < 100ms
-            print('SYNC: FAIR (spread < 100ms)')
+        spread = max(offsets) - min(offsets)
+        avg_off = mean(offsets)
+        print(f'Source-offset spread: {spread} frames ({spread/48.0:.2f}ms)')
+        print(f'Min relative offset: {min(offsets):+d}, Max relative offset: {max(offsets):+d}, Avg: {avg_off:+.1f}')
+        if spread < 48:  # < 1ms
+            print('SYNC: GOOD (spread < 1ms)')
+        elif spread < 480:  # < 10ms
+            print('SYNC: FAIR (spread < 10ms)')
         else:
-            print('SYNC: POOR (spread >= 100ms)')
+            print('SYNC: POOR (spread >= 10ms)')
 " || echo "Cross-stream comparison failed"
 
 echo ""
 echo "=== Summary ==="
 echo "Streams: ${STREAM_COUNT}"
 echo "Captures present: ${ok}/${total}"
-echo "Signal present: ${signal_present}/${total}"
+echo "Bit-perfect overlap: ${bit_perfect}/${total}"
+if [ "$bit_perfect" -ne "$total" ]; then
+    echo "FAIL: not all captures produced a bit-perfect overlap"
+    exit 1
+fi
 echo ""
 echo "=== Multi-stream test complete ==="

--- a/test/docker-compose.multi.yml
+++ b/test/docker-compose.multi.yml
@@ -98,7 +98,10 @@ services:
 
   sendspin_source:
     build:
-      context: ./sendspin_source
+      context: .
+      dockerfile: ./sendspin_source/Dockerfile
+    volumes:
+      - shared:/shared
     networks:
       - audio_net
     depends_on:
@@ -144,7 +147,8 @@ services:
   # --- Test orchestrator ---
   control_and_test:
     build:
-      context: ./control_and_test_multi
+      context: .
+      dockerfile: ./control_and_test_multi/Dockerfile
     volumes:
       - shared:/shared
     networks:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -51,7 +51,10 @@ services:
   # Sendspin test source
   sendspin_source:
     build:
-      context: ./sendspin_source
+      context: .
+      dockerfile: ./sendspin_source/Dockerfile
+    volumes:
+      - shared:/shared
     networks:
       - audio_net
     depends_on:
@@ -111,7 +114,8 @@ services:
   # Test orchestrator
   control_and_test:
     build:
-      context: ./control_and_test
+      context: .
+      dockerfile: ./control_and_test/Dockerfile
     volumes:
       - shared:/shared
     networks:

--- a/test/sendspin_source/Dockerfile
+++ b/test/sendspin_source/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.13-alpine
 RUN apk add --no-cache ffmpeg
 RUN pip install --no-cache-dir sendspin
-COPY entrypoint.sh /entrypoint.sh
+COPY sendspin_source/entrypoint.sh /entrypoint.sh
+COPY common/generate_reference_signal.py /generate_reference_signal.py
 RUN chmod +x /entrypoint.sh
 EXPOSE 8927
 ENTRYPOINT ["/entrypoint.sh"]

--- a/test/sendspin_source/entrypoint.sh
+++ b/test/sendspin_source/entrypoint.sh
@@ -1,26 +1,9 @@
 #!/bin/sh
 set -e
 
-# Generate a 30-second test tone WAV file (1kHz sine, 48kHz, 16-bit, stereo)
-python3 -c "
-import struct, math, wave
+python3 /generate_reference_signal.py \
+  --wav-path /tmp/test_signal.wav \
+  --capture-raw-path /shared/reference_capture.raw
 
-sample_rate = 48000
-duration = 30
-freq = 1000
-amplitude = 16000  # well below 16-bit max
-
-with wave.open('/tmp/test_tone.wav', 'w') as wav:
-    wav.setnchannels(2)
-    wav.setsampwidth(2)  # 16-bit
-    wav.setframerate(sample_rate)
-    for i in range(sample_rate * duration):
-        val = int(amplitude * math.sin(2 * math.pi * freq * i / sample_rate))
-        frame = struct.pack('<hh', val, val)  # stereo
-        wav.writeframes(frame)
-
-print(f'Generated: {duration}s, {freq}Hz sine, {sample_rate}Hz, 16-bit stereo WAV')
-"
-
-echo "Starting Sendspin server with test tone..."
-exec sendspin serve --name "TestSource" --log-level DEBUG /tmp/test_tone.wav
+echo "Starting Sendspin server with deterministic reference signal..."
+exec sendspin serve --name "TestSource" --log-level DEBUG /tmp/test_signal.wav


### PR DESCRIPTION
## Summary
- replace the weak signal-presence checks with deterministic overlap-based comparison
- generate a shared deterministic 24-bit reference WAV plus capture-domain raw reference for tests
- report per-capture bit-perfect overlap and cross-stream source-offset spread in the multi-stream harness
- update `TESTING.md` to document the new verification model and current container topology

## Why
The old harness could tell us that audio existed, but it could not tell us whether the received PCM matched what was sent. That let amplitude, alignment, and gap bugs slip through longer than they should have.

This change upgrades the tests to verify a stronger property:
- allow an unknown dropped prefix/suffix at startup/shutdown
- require the received overlap to match the reference exactly and continuously

That is a much better fit for the way these streams start in practice, and it gives us a way to catch payload-integrity bugs without pretending we can require source sample 0 to always be present.

## What landed in this branch
- deterministic reference generation in `test/sendspin_source`
- shared comparison helper in `test/common/audio_compare.py`
- single-stream harness switched from signal-presence to overlap comparison
- multi-stream harness switched to overlap comparison plus source-offset spread reporting
- follow-up comparator optimization so the comparison fails fast instead of stalling on full-size captures

## Validation
Sanity checks:
- exact self-comparison passes
- shifted overlap passes
- injected internal gap fails
- `docker compose -f test/docker-compose.yml config`
- `docker compose -f test/docker-compose.multi.yml config`

Real Docker run from this branch:
- `make test`
- result: the harness now reaches the comparison step and fails cleanly with:
  - `[capture.raw] alignment_found=False`
  - `no exact alignment window found`

So this branch should currently be read as:
- the stronger test harness is implemented
- the comparison path is fast enough to use
- the current single-stream pipeline does **not** yet produce a bit-perfect overlap match against the deterministic reference

## Current status
This PR improves our ability to detect payload-integrity bugs, and it is already surfacing a real mismatch that the previous harness would not have caught.

It should **not** be interpreted as "tests are now passing". At the moment, the new harness is exposing that we still need follow-up work in the audio path before we get a clean overlap match.

Fixes https://github.com/salanki/spin2dante/issues/1 
