### PR TITLE
Add experimental Dante bit-depth configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Bridge from Sendspin audio streams to DANTE (Audio over IP) via i
 license = "GPL-3.0-or-later OR AGPL-3.0-or-later"
 
 [dependencies]
-inferno_aoip = { git = "https://github.com/salanki/inferno.git", rev = "5b1c9d1" }
+inferno_aoip = { git = "https://github.com/salanki/inferno.git", rev = "7fc7c5e" }
 sendspin = "0.1"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,7 +34,7 @@ Sendspin Server (Music Assistant)
    DANTE Receivers
 ```
 
-The bridge uses a fork of inferno_aoip (pinned to commit `5b1c9d1`) that adds `transmit_from_owned_buffer()` and `ReadPositionSnapshot`.
+The bridge uses a fork of inferno_aoip (pinned to commit `7fc7c5e`) that adds `transmit_from_owned_buffer()`, `ReadPositionSnapshot`, and configurable Dante TX bit depth.
 
 ## Two-Stage Queue
 
@@ -48,7 +48,7 @@ The pending queue decouples chunk arrival from ring placement. Chunks are draine
 
 ### Buffer capacity
 
-The bridge advertises a small `buffer_capacity` (~500ms of stereo 24-bit PCM) via the Sendspin `PlayerV1Support` handshake, so the server doesn't send audio too far ahead of real-time.
+The bridge advertises a small `buffer_capacity` (~500ms of stereo PCM) via the Sendspin `PlayerV1Support` handshake, so the server doesn't send audio too far ahead of real-time.
 
 ## Cross-Bridge Sync Architecture
 
@@ -165,15 +165,22 @@ process start → Idle (device + TX alive, ring silent)
 
 ## Sample Format Alignment
 
+- **Sendspin PCM 32-bit**: 4 bytes LE signed → parse as i32
 - **Sendspin PCM 24-bit**: 3 bytes LE signed → sign-extend to i32 → shift left 8
 - **Sendspin PCM 16-bit**: 2 bytes LE signed → cast to i32 → shift left 16
-- **Inferno `Sample`**: i32 with 24-bit value in upper 24 bits
+- **Inferno `Sample`**: i32 transport sample used by inferno TX
 
-The bridge currently advertises and accepts PCM `16-bit` and `24-bit` Sendspin streams. Both are transported losslessly through Inferno's `Sample` representation.
+The bridge advertises Sendspin PCM formats based on the configured Dante TX bit depth:
 
-`TX_SOURCE_BIT_DEPTH` is intentionally fixed to `24`. This is not a statement that the bridge only supports 24-bit source audio; it reflects Inferno's 24-bit-oriented TX sample path and keeps TX dithering disabled for bit-perfect PCM transport.
+- `--dante-bit-depth 16` → advertise `16-bit`
+- `--dante-bit-depth 24` → advertise `24-bit`, `16-bit`
+- `--dante-bit-depth 32` → advertise `32-bit`, `24-bit`, `16-bit`
 
-This is an implementation choice, not a fundamental architectural limit. Supporting wider PCM formats in the future would require explicit protocol, decode, and TX-path validation, but the bridge design itself is not inherently restricted to only `16-bit` and `24-bit` PCM.
+All advertised formats are transported losslessly through Inferno's `Sample` representation.
+
+The bridge sets both Inferno `BITS_PER_SAMPLE` and `TX_SOURCE_BIT_DEPTH` to the configured Dante TX depth. `BITS_PER_SAMPLE` controls the actual Dante flow format; `TX_SOURCE_BIT_DEPTH` controls Inferno's dithering decision.
+
+This is still an implementation choice, not a fundamental architectural limit. Supporting wider PCM formats in the future would require explicit protocol, decode, and TX-path validation, but the bridge design itself is not inherently restricted to only `16-bit`, `24-bit`, and `32-bit` PCM.
 
 ## Player Capabilities
 
@@ -185,12 +192,13 @@ One bridge process per Sendspin stream. Each bridge needs unique `INFERNO_PROCES
 
 ## Inferno Fork
 
-[`github.com/salanki/inferno`](https://github.com/salanki/inferno/tree/spin2dante-owned-buffer), pinned to commit `5b1c9d1`:
+[`github.com/salanki/inferno`](https://github.com/salanki/inferno/tree/spin2dante-owned-buffer), pinned to commit `7fc7c5e`:
 
 - `transmit_from_owned_buffer()` — creates owned ring buffers, returns `RBInput` handles
 - `ReadPositionSnapshot` — seqlock `(read_pos, monotonic_nanos, ref_instant)` for precise timing
 - `read_position: Arc<AtomicUsize>` — exposes TX consumer cursor
-- `TX_SOURCE_BIT_DEPTH` — controls dithering (set to 24 for bit-perfect PCM)
+- `BITS_PER_SAMPLE` — controls the actual Dante TX bit depth
+- `TX_SOURCE_BIT_DEPTH` — controls dithering relative to that TX format
 
 ## Lessons Learned
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ INFERNO_DIR ?= ../inferno
 MUSIC_ASSISTANT_COMPOSE ?= test/music_assistant/docker-compose.yml
 MUSIC_ASSISTANT_DOCKER_CONFIG ?= /tmp/music-assistant-docker-config
 
-.PHONY: build test test-multi test-sync-verify test-resilience test-ma-interactive ma-up ma-down ma-logs clean
+.PHONY: build test test-32 test-multi test-sync-verify test-resilience test-ma-interactive ma-up ma-down ma-logs clean
 
 ## Build the bridge Docker image
 build:
@@ -19,6 +19,14 @@ test: build inferno2pipe
 	docker compose up --build --abort-on-container-exit control_and_test; \
 	result=$$?; \
 	docker compose down --remove-orphans; \
+	exit $$result
+
+## Run the single-stream 32-bit PCM smoke test
+test-32: build inferno2pipe
+	cd test && docker compose -f docker-compose.32.yml down --remove-orphans 2>/dev/null; \
+	docker compose -f docker-compose.32.yml up --build --abort-on-container-exit control_and_test; \
+	result=$$?; \
+	docker compose -f docker-compose.32.yml down --remove-orphans; \
 	exit $$result
 
 ## Run the multi-stream E2E test (4 synchronized streams)
@@ -73,6 +81,7 @@ ma-logs:
 ## Remove all test containers, networks, and volumes
 clean:
 	cd test && docker compose down --remove-orphans --volumes 2>/dev/null || true
+	cd test && docker compose -f docker-compose.32.yml down --remove-orphans --volumes 2>/dev/null || true
 	cd test && docker compose -f docker-compose.multi.yml down --remove-orphans --volumes 2>/dev/null || true
 	cd test && docker compose -f docker-compose.resilience.yml down --remove-orphans --volumes 2>/dev/null || true
 	cd test && docker compose -f docker-compose.sync-verify.yml down --remove-orphans --volumes 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ During PTP clock warmup, the buffer line shows:
 |---------|-------|-----|
 | `clock unavailable, can't transmit` | Statime not running, not synced, or no PTP master on network | Check `docker compose logs statime`. Ensure DANTE hardware is on the network as PTP master. |
 | `no active DANTE subscriber` | No DANTE receiver subscribed to this bridge | Use Dante Controller or `netaudio subscription add` to route channels |
-| `rejecting stream: codec 'flac'` | Sendspin source sending FLAC (not yet supported) | Configure source to send PCM. Bridge supports PCM 16/24-bit only. |
+| `rejecting stream: codec 'flac'` | Sendspin source sending FLAC (not yet supported) | Configure source to send PCM. Bridge supports PCM 16/24/32-bit depending on `--dante-bit-depth`. |
 | `rejecting stream: sample rate` | Source not at 48kHz | Configure source for 48kHz output |
 | `connection failed ... retrying` | Sendspin server not reachable | Check URL, ensure Music Assistant is running |
 | `session ended with error ... reconnecting` | Sendspin server restarted or network glitch | Normal — bridge auto-reconnects in 2 seconds |

--- a/TESTING.md
+++ b/TESTING.md
@@ -63,6 +63,9 @@ Notes:
 # Single-stream E2E test (1 bridge, 1 receiver)
 make test
 
+# 32-bit PCM smoke test (1 bridge, 1 receiver)
+make test-32
+
 # Multi-stream E2E test (4 bridges in one Sendspin group, 4 receivers)
 make test-multi
 
@@ -436,7 +439,7 @@ Tested and validated via `make test-resilience`:
 | **Stream seek (StreamClear)** | Stale buffered audio is zeroed from current read position. Bridge enters rebuffer mode, refills jitter buffer with fresh data, then resumes. |
 | **Stream ends (StreamEnd)** | Ring zeroed, bridge enters Idle. DANTE device stays on network. |
 | **New stream with same format (StreamStart, already Running)** | Stale audio cleared, rebuffer mode, no device restart. |
-| **New stream with different format** | Format validated; if supported (PCM 16/24-bit), stream_format updated and enters WaitingForSubscriber. Unsupported formats rejected. Device is NOT restarted. |
+| **New stream with different format** | Format validated; if supported for the configured Dante bit depth (PCM 16/24/32-bit), `stream_format` is updated and the bridge enters WaitingForSubscriber. Unsupported formats are rejected. Device is NOT restarted. |
 | **PTP master disappears** | Statime stops exporting clock overlays. FlowsTransmitter reports "clock unavailable" until PTP master returns. Audio stops but bridge stays alive. |
 | **Multiple StreamStart without StreamEnd** | If already Running with same format: clear + rebuffer. Otherwise: enter WaitingForSubscriber. |
 

--- a/addons/spin2dante/DOCS.md
+++ b/addons/spin2dante/DOCS.md
@@ -30,6 +30,7 @@ Each bridge entry contains:
 - `name`: DANTE device name to advertise
 - `url`: Sendspin WebSocket URL
 - `buffer_ms`: Jitter buffer size in milliseconds
+- `dante_bit_depth`: Dante TX bit depth (`16`, `24`, or `32`)
 - `process_id`: Unique Inferno process ID on the host IP
 - `alt_port`: Unique Inferno base UDP port, spaced at least 10 apart from other bridges
 
@@ -44,12 +45,14 @@ bridges:
     name: Kitchen
     url: ws://music-assistant.local:8927/sendspin
     buffer_ms: 50
+    dante_bit_depth: 24
     process_id: 1
     alt_port: 14000
   - id: livingroom
     name: Living Room
     url: ws://music-assistant.local:8927/sendspin
     buffer_ms: 50
+    dante_bit_depth: 24
     process_id: 2
     alt_port: 14010
 ```

--- a/addons/spin2dante/config.yaml
+++ b/addons/spin2dante/config.yaml
@@ -36,12 +36,14 @@ options:
       name: Kitchen
       url: "ws://music-assistant.local:8927/sendspin"
       buffer_ms: 50
+      dante_bit_depth: 24
       process_id: 1
       alt_port: 14000
     - id: livingroom
       name: "Living Room"
       url: "ws://music-assistant.local:8927/sendspin"
       buffer_ms: 50
+      dante_bit_depth: 24
       process_id: 2
       alt_port: 14010
 schema:
@@ -53,5 +55,6 @@ schema:
       name: str
       url: str
       buffer_ms: int(10,5000)
+      dante_bit_depth: list(16|24|32)
       process_id: int(1,65535)
       alt_port: int(1024,65532)

--- a/addons/spin2dante/run.sh
+++ b/addons/spin2dante/run.sh
@@ -95,6 +95,7 @@ for ((i = 0; i < BRIDGE_COUNT; i++)); do
     name="$(jq -r ".bridges[$i].name" "$OPTIONS_FILE")"
     url="$(jq -r ".bridges[$i].url" "$OPTIONS_FILE")"
     buffer_ms="$(jq -r ".bridges[$i].buffer_ms" "$OPTIONS_FILE")"
+    dante_bit_depth="$(jq -r ".bridges[$i].dante_bit_depth" "$OPTIONS_FILE")"
     process_id="$(jq -r ".bridges[$i].process_id" "$OPTIONS_FILE")"
     alt_port="$(jq -r ".bridges[$i].alt_port" "$OPTIONS_FILE")"
     tmpdir="/share/tmp_${id}"
@@ -108,7 +109,8 @@ for ((i = 0; i < BRIDGE_COUNT; i++)); do
     /usr/local/bin/spin2dante \
         --url "$url" \
         --name "$name" \
-        --buffer-ms "$buffer_ms" &
+        --buffer-ms "$buffer_ms" \
+        --dante-bit-depth "$dante_bit_depth" &
 
     PIDS+=("$!")
 done

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use atomic::Atomic;
-use inferno_aoip::device_server::{DeviceServer, OwnedBuffer, RBInput, ReadPositionSnapshot, Sample, Settings};
+use inferno_aoip::device_server::{
+    DeviceServer, OwnedBuffer, RBInput, ReadPositionSnapshot, Sample, Settings,
+};
 use log::{debug, error, info, warn};
 use sendspin::protocol::client::AudioChunk;
 use sendspin::protocol::messages::{AudioFormatSpec, Message, PlayerV1Support};
@@ -62,6 +64,7 @@ pub struct SendspinBridge {
     device_name: String,
     client_id: String,
     buffer_ms: u32,
+    dante_bit_depth: u8,
     state: BridgeState,
     // Device + TX state (persistent for process lifetime)
     rb_inputs: Option<Vec<RBInput<Sample, OwnedBuffer<Atomic<Sample>>>>>,
@@ -93,13 +96,20 @@ pub struct SendspinBridge {
 }
 
 impl SendspinBridge {
-    pub fn new(url: String, device_name: String, buffer_ms: u32, client_id: String) -> Self {
+    pub fn new(
+        url: String,
+        device_name: String,
+        buffer_ms: u32,
+        dante_bit_depth: u8,
+        client_id: String,
+    ) -> Self {
         let prebuffer_target = (SAMPLE_RATE as usize * buffer_ms as usize) / 1000;
         Self {
             url,
             device_name,
             client_id,
             buffer_ms,
+            dante_bit_depth,
             state: BridgeState::Idle,
             rb_inputs: None,
             device_server: None,
@@ -147,7 +157,14 @@ impl SendspinBridge {
         let short_name = self.device_name.chars().take(14).collect::<String>();
         let mut config = std::collections::BTreeMap::new();
         config.insert("NAME".to_string(), self.device_name.clone());
-        config.insert("TX_SOURCE_BIT_DEPTH".to_string(), "24".to_string());
+        config.insert(
+            "TX_SOURCE_BIT_DEPTH".to_string(),
+            self.dante_bit_depth.to_string(),
+        );
+        config.insert(
+            "BITS_PER_SAMPLE".to_string(),
+            self.dante_bit_depth.to_string(),
+        );
         config.insert("SAMPLE_RATE".to_string(), SAMPLE_RATE.to_string());
         let mut settings = Settings::new(&self.device_name, &short_name, None, &config);
         settings.make_tx_channels(CHANNELS);
@@ -195,21 +212,17 @@ impl SendspinBridge {
             // audio too far ahead of real-time. The pending queue + ring need
             // the server lead to fit within RING_BUFFER_SIZE (~341ms).
             let player_support = PlayerV1Support {
-                supported_formats: vec![
-                    AudioFormatSpec {
+                supported_formats: self
+                    .supported_sendspin_bit_depths()
+                    .into_iter()
+                    .map(|bit_depth| AudioFormatSpec {
                         codec: "pcm".to_string(),
                         channels: CHANNELS as u8,
                         sample_rate: SAMPLE_RATE,
-                        bit_depth: 24,
-                    },
-                    AudioFormatSpec {
-                        codec: "pcm".to_string(),
-                        channels: CHANNELS as u8,
-                        sample_rate: SAMPLE_RATE,
-                        bit_depth: 16,
-                    },
-                ],
-                buffer_capacity: (SAMPLE_RATE as u32 * CHANNELS as u32 * 3 / 5), // ~200ms stereo 24-bit
+                        bit_depth,
+                    })
+                    .collect(),
+                buffer_capacity: (SAMPLE_RATE as u32 * CHANNELS as u32 * 3 / 5), // ~200ms stereo PCM
                 supported_commands: vec![],
             };
             match ProtocolClientBuilder::builder()
@@ -300,10 +313,15 @@ impl SendspinBridge {
                         );
                         return;
                     }
-                    if format.bit_depth != 16 && format.bit_depth != 24 {
+                    if !self.supports_sendspin_bit_depth(format.bit_depth) {
                         error!(
-                            "rejecting stream: PCM bit depth {}, only 16 or 24 supported",
-                            format.bit_depth
+                            "rejecting stream: PCM bit depth {}, supported: {}",
+                            format.bit_depth,
+                            self.supported_sendspin_bit_depths()
+                                .into_iter()
+                                .map(|depth| depth.to_string())
+                                .collect::<Vec<_>>()
+                                .join(", ")
                         );
                         return;
                     }
@@ -712,8 +730,22 @@ impl SendspinBridge {
 
     // ─── PCM decode ─────────────────────────────────────────────────
 
+    fn supported_sendspin_bit_depths(&self) -> Vec<u8> {
+        match self.dante_bit_depth {
+            32 => vec![32, 24, 16],
+            24 => vec![24, 16],
+            16 => vec![16],
+            other => panic!("unsupported dante bit depth {other}"),
+        }
+    }
+
+    fn supports_sendspin_bit_depth(&self, bit_depth: u8) -> bool {
+        self.supported_sendspin_bit_depths().contains(&bit_depth)
+    }
+
     fn decode_pcm(&self, data: &[u8], format: &StreamFormat) -> (usize, Vec<Vec<Sample>>) {
         let (bytes_per_sample, frames) = match format.bit_depth {
+            32 => (4, data.len() / (4 * CHANNELS)),
             24 => (3, data.len() / (3 * CHANNELS)),
             16 => (2, data.len() / (2 * CHANNELS)),
             _ => return (0, vec![]),
@@ -725,15 +757,23 @@ impl SendspinBridge {
         for frame in 0..frames {
             for ch in 0..CHANNELS {
                 let offset = frame * frame_size + ch * bytes_per_sample;
-                let sample = if bytes_per_sample == 3 {
-                    let b = &data[offset..offset + 3];
-                    let raw = (b[0] as i32) | ((b[1] as i32) << 8) | ((b[2] as i32) << 16);
-                    let sign_extended = (raw << 8) >> 8;
-                    sign_extended << 8
-                } else {
-                    let b = &data[offset..offset + 2];
-                    let raw = i16::from_le_bytes([b[0], b[1]]) as i32;
-                    raw << 16
+                let sample = match bytes_per_sample {
+                    4 => {
+                        let b = &data[offset..offset + 4];
+                        i32::from_le_bytes([b[0], b[1], b[2], b[3]])
+                    }
+                    3 => {
+                        let b = &data[offset..offset + 3];
+                        let raw = (b[0] as i32) | ((b[1] as i32) << 8) | ((b[2] as i32) << 16);
+                        let sign_extended = (raw << 8) >> 8;
+                        sign_extended << 8
+                    }
+                    2 => {
+                        let b = &data[offset..offset + 2];
+                        let raw = i16::from_le_bytes([b[0], b[1]]) as i32;
+                        raw << 16
+                    }
+                    _ => unreachable!("unsupported PCM width"),
                 };
                 channels[ch].push(sample);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ Bridges Sendspin audio streams (e.g., from Music Assistant) to DANTE
 network audio using inferno_aoip. Stereo (2-channel) only.
 
 Receives audio via WebSocket from a Sendspin server and transmits it
-as a DANTE device on the local network. Bit-perfect for PCM (16/24-bit).
+as a DANTE device on the local network. Bit-perfect for PCM (16/24/32-bit).
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License (v3+) or the
@@ -34,6 +34,10 @@ struct Args {
     #[arg(long, default_value_t = 50)]
     buffer_ms: u32,
 
+    /// Dante TX bit depth (also caps advertised Sendspin PCM formats)
+    #[arg(long, default_value_t = 24, value_parser = parse_dante_bit_depth)]
+    dante_bit_depth: u8,
+
     /// Stable Sendspin client ID. If omitted, derived from name (+ INFERNO_PROCESS_ID if set).
     #[arg(long)]
     client_id: Option<String>,
@@ -47,14 +51,22 @@ async fn main() {
     let args = Args::parse();
 
     info!(
-        "spin2dante starting: url={} name={} buffer={}ms",
-        args.url, args.name, args.buffer_ms
+        "spin2dante starting: url={} name={} buffer={}ms dante_bit_depth={}",
+        args.url, args.name, args.buffer_ms, args.dante_bit_depth
     );
 
-    let client_id = args.client_id.unwrap_or_else(|| derive_client_id(&args.name));
+    let client_id = args
+        .client_id
+        .unwrap_or_else(|| derive_client_id(&args.name));
     info!("using Sendspin client_id={}", client_id);
 
-    let mut bridge = bridge::SendspinBridge::new(args.url, args.name, args.buffer_ms, client_id);
+    let mut bridge = bridge::SendspinBridge::new(
+        args.url,
+        args.name,
+        args.buffer_ms,
+        args.dante_bit_depth,
+        client_id,
+    );
 
     if let Err(e) = bridge.run().await {
         log::error!("bridge error: {e}");
@@ -80,4 +92,14 @@ fn fnv1a64(bytes: &[u8]) -> u64 {
         hash = hash.wrapping_mul(0x100000001b3);
     }
     hash
+}
+
+fn parse_dante_bit_depth(value: &str) -> Result<u8, String> {
+    let bit_depth = value
+        .parse::<u8>()
+        .map_err(|_| "dante bit depth must be one of: 16, 24, 32".to_string())?;
+    match bit_depth {
+        16 | 24 | 32 => Ok(bit_depth),
+        _ => Err("dante bit depth must be one of: 16, 24, 32".to_string()),
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -40,11 +40,13 @@ impl BufferMetrics {
             let deviation = fill - target;
             if let Some(last_time) = self.last_log_time {
                 let interval = now.duration_since(last_time).as_secs_f64();
-                let last_fill = (self.last_write_pos as isize).wrapping_sub(self.last_read_pos as isize);
+                let last_fill =
+                    (self.last_write_pos as isize).wrapping_sub(self.last_read_pos as isize);
                 let fill_change = fill - last_fill;
                 if interval > 0.0 {
                     let drift_samples_per_sec = fill_change as f64 / interval;
-                    let drift_ppm = (drift_samples_per_sec / super::bridge::SAMPLE_RATE as f64) * 1_000_000.0;
+                    let drift_ppm =
+                        (drift_samples_per_sec / super::bridge::SAMPLE_RATE as f64) * 1_000_000.0;
                     format!("{:+.1}ppm", drift_ppm)
                 } else {
                     "n/a".to_string()

--- a/test/control_and_test/control_and_test.sh
+++ b/test/control_and_test/control_and_test.sh
@@ -47,7 +47,8 @@ fi
 netaudio subscription add --tx "02@${bridge_name}" --rx "02@i2pipe" || echo "Sub 2 failed"
 echo "Using bridge name: '$bridge_name'"
 
-echo "Subscriptions created. Recording for 20 seconds..."
+touch /shared/start_stream
+echo "Subscriptions created. Start signal written. Recording for 20 seconds..."
 sleep 20
 
 echo ""

--- a/test/docker-compose.32.yml
+++ b/test/docker-compose.32.yml
@@ -1,0 +1,120 @@
+## Single-stream 32-bit PCM smoke test
+
+volumes:
+  shared:
+
+networks:
+  audio_net:
+    driver: bridge
+
+services:
+  init:
+    image: alpine:3
+    command: sh -c "rm -rf /shared/* && echo 'shared volume cleared'"
+    volumes:
+      - shared:/shared
+
+  ptp-master:
+    build:
+      context: ../statime
+    cap_add:
+      - SYS_TIME
+    environment:
+      STATIME_CONFIG: /etc/statime-ptpv2-master.toml
+    volumes:
+      - shared:/shared
+      - ../statime/statime-ptpv2-master.toml:/etc/statime-ptpv2-master.toml:ro
+    networks:
+      - audio_net
+    depends_on:
+      init:
+        condition: service_completed_successfully
+
+  ptp-follower:
+    build:
+      context: ../statime
+    cap_add:
+      - SYS_TIME
+    environment:
+      STATIME_CONFIG: /etc/statime-ptpv2-follower.toml
+    volumes:
+      - shared:/shared
+      - ../statime/statime-ptpv2-follower.toml:/etc/statime-ptpv2-follower.toml:ro
+    networks:
+      - audio_net
+    depends_on:
+      ptp-master:
+        condition: service_started
+
+  sendspin_source:
+    build:
+      context: .
+      dockerfile: ./sendspin_source_32/Dockerfile
+    volumes:
+      - shared:/shared
+    networks:
+      - audio_net
+    depends_on:
+      init:
+        condition: service_completed_successfully
+
+  bridge:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["mkdir -p /shared/tmp_bridge && exec spin2dante --url ws://sendspin_source:8927/sendspin --name SSBridge32 --dante-bit-depth 32"]
+    environment:
+      INFERNO_CLOCK_PATH: /shared/usrvclock
+      TMPDIR: /shared/tmp_bridge
+      RUST_LOG: "info"
+    volumes:
+      - shared:/shared
+    networks:
+      - audio_net
+    ulimits:
+      memlock: 200000000
+    shm_size: 200m
+    depends_on:
+      ptp-follower:
+        condition: service_started
+      sendspin_source:
+        condition: service_started
+
+  i2pipe:
+    image: inferno_aoip:alpine-i2pipe
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["mkdir -p /shared/tmp_i2pipe && sleep 15 && inferno2pipe -c 2 -o /shared/capture.raw"]
+    environment:
+      INFERNO_CLOCK_PATH: /shared/usrvclock
+      INFERNO_NAME: i2pipe
+      INFERNO_SAMPLE_RATE: "48000"
+      INFERNO_RX_CHANNELS: "2"
+      INFERNO_TX_CHANNELS: "0"
+      TMPDIR: /shared/tmp_i2pipe
+    volumes:
+      - shared:/shared
+    networks:
+      - audio_net
+    ulimits:
+      memlock: 200000000
+    shm_size: 200m
+    depends_on:
+      ptp-follower:
+        condition: service_started
+      bridge:
+        condition: service_started
+
+  control_and_test:
+    build:
+      context: .
+      dockerfile: ./control_and_test/Dockerfile
+    volumes:
+      - shared:/shared
+    networks:
+      - audio_net
+    depends_on:
+      bridge:
+        condition: service_started
+      i2pipe:
+        condition: service_started

--- a/test/sendspin_source_32/Dockerfile
+++ b/test/sendspin_source_32/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.13-alpine
+RUN pip install --no-cache-dir websockets
+COPY sendspin_source_32/server.py /server.py
+EXPOSE 8927
+ENTRYPOINT ["python3", "/server.py"]

--- a/test/sendspin_source_32/server.py
+++ b/test/sendspin_source_32/server.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Minimal Sendspin test source that emits deterministic 32-bit PCM."""
+
+import asyncio
+import contextlib
+import json
+import os
+import struct
+import time
+
+import websockets
+
+SAMPLE_RATE = 48000
+CHANNELS = 2
+BIT_DEPTH = 32
+BYTES_PER_SAMPLE = BIT_DEPTH // 8
+FRAME_SIZE = BYTES_PER_SAMPLE * CHANNELS
+CHUNK_FRAMES = 480
+PORT = 8927
+STREAM_DURATION_SECS = 30
+START_SIGNAL_PATH = "/shared/start_stream"
+
+stream_served = False
+SERVER_MONO_BASE_US = time.monotonic_ns() // 1_000
+
+
+def xorshift32(state: int) -> int:
+    state &= 0xFFFFFFFF
+    state ^= (state << 13) & 0xFFFFFFFF
+    state ^= (state >> 17) & 0xFFFFFFFF
+    state ^= (state << 5) & 0xFFFFFFFF
+    return state & 0xFFFFFFFF
+
+
+def to_signed_32(state: int) -> int:
+    sample = state & 0xFFFFFFFF
+    if sample >= 0x80000000:
+        sample -= 0x100000000
+    return sample
+
+
+def generate_reference_capture(path: str) -> None:
+    left_state = 0x13579BDF
+    right_state = 0x2468ACE1
+    total_frames = STREAM_DURATION_SECS * SAMPLE_RATE
+
+    with open(path, "wb") as raw_file:
+        for _ in range(total_frames):
+            left_state = xorshift32(left_state)
+            right_state = xorshift32(right_state)
+            raw_file.write(struct.pack("<i", to_signed_32(left_state)))
+            raw_file.write(struct.pack("<i", to_signed_32(right_state)))
+
+
+def make_text_msg(msg_type: str, payload: dict | None = None) -> str:
+    obj = {"type": msg_type, "payload": payload or {}}
+    return json.dumps(obj)
+
+
+def make_audio_binary(timestamp_us: int, pcm_data: bytes) -> bytes:
+    return struct.pack(">Bq", 4, timestamp_us) + pcm_data
+
+
+def server_now_us() -> int:
+    return (time.monotonic_ns() // 1_000) - SERVER_MONO_BASE_US
+
+
+def generate_chunk(left_state: int, right_state: int, frames: int) -> tuple[bytes, int, int]:
+    data = bytearray(frames * FRAME_SIZE)
+    for frame in range(frames):
+        left_state = xorshift32(left_state)
+        right_state = xorshift32(right_state)
+        offset = frame * FRAME_SIZE
+        data[offset : offset + 4] = struct.pack("<i", to_signed_32(left_state))
+        data[offset + 4 : offset + 8] = struct.pack("<i", to_signed_32(right_state))
+    return bytes(data), left_state, right_state
+
+
+async def send_audio(ws) -> None:
+    left_state = 0x13579BDF
+    right_state = 0x2468ACE1
+    frames_total = SAMPLE_RATE * STREAM_DURATION_SECS
+    frames_sent = 0
+    ts = server_now_us() + 200_000
+
+    while frames_sent < frames_total:
+        chunk, left_state, right_state = generate_chunk(left_state, right_state, CHUNK_FRAMES)
+        await ws.send(make_audio_binary(ts, chunk))
+        frames_sent += CHUNK_FRAMES
+        ts += int(CHUNK_FRAMES / SAMPLE_RATE * 1_000_000)
+        await asyncio.sleep(CHUNK_FRAMES / SAMPLE_RATE)
+
+
+async def wait_for_start_signal() -> None:
+    print(f"[server] waiting for start signal at {START_SIGNAL_PATH}", flush=True)
+    while not os.path.exists(START_SIGNAL_PATH):
+        await asyncio.sleep(0.2)
+    print("[server] start signal detected", flush=True)
+
+
+async def handle_client_messages(ws, sync_ready: asyncio.Event) -> None:
+    time_sync_count = 0
+    async for raw in ws:
+        if not isinstance(raw, str):
+            continue
+        msg = json.loads(raw)
+        msg_type = msg.get("type")
+        payload = msg.get("payload", {})
+        if msg_type == "client/time":
+            client_transmitted = payload.get("client_transmitted")
+            server_received = server_now_us()
+            time_sync_count += 1
+            if time_sync_count == 1 or time_sync_count % 5 == 0:
+                print(
+                    f"[server] client/time #{time_sync_count}: client={client_transmitted} server={server_received}",
+                    flush=True,
+                )
+            await ws.send(
+                make_text_msg(
+                    "server/time",
+                    {
+                        "client_transmitted": client_transmitted,
+                        "server_received": server_received,
+                        "server_transmitted": server_now_us(),
+                    },
+                )
+            )
+            if time_sync_count >= 5:
+                sync_ready.set()
+        elif msg_type == "client/state":
+            continue
+
+
+async def handle_client(ws):
+    global stream_served
+
+    raw = await ws.recv()
+    hello = json.loads(raw)
+    print(f"[server] got hello: {hello.get('type', 'unknown')}", flush=True)
+
+    await ws.send(
+        make_text_msg(
+            "server/hello",
+            {
+                "server_id": "pcm32-test-source",
+                "name": "PCM32 Test Source",
+                "version": 1,
+                "active_roles": ["player@v1"],
+                "connection_reason": "playback",
+            },
+        )
+    )
+
+    if stream_served:
+        print("[server] stream already served once; closing connection", flush=True)
+        await ws.close()
+        return
+
+    sync_ready = asyncio.Event()
+    message_task = asyncio.create_task(handle_client_messages(ws, sync_ready))
+
+    try:
+        await wait_for_start_signal()
+        try:
+            await asyncio.wait_for(sync_ready.wait(), timeout=5.0)
+            print("[server] clock sync ready, starting stream", flush=True)
+        except asyncio.TimeoutError:
+            print("[server] clock sync not ready within 5s, starting anyway", flush=True)
+        stream_served = True
+
+        await ws.send(
+            make_text_msg(
+                "stream/start",
+                {
+                    "player": {
+                        "codec": "pcm",
+                        "sample_rate": SAMPLE_RATE,
+                        "channels": CHANNELS,
+                        "bit_depth": BIT_DEPTH,
+                    }
+                },
+            )
+        )
+        print("[server] sent stream/start (32-bit PCM)", flush=True)
+        await send_audio(ws)
+        await ws.send(make_text_msg("stream/end", {}))
+        print("[server] sent stream/end", flush=True)
+        await ws.close()
+    finally:
+        message_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await message_task
+
+
+async def main() -> None:
+    generate_reference_capture("/shared/reference_capture.raw")
+    print("[server] generated deterministic 32-bit reference capture", flush=True)
+
+    async with websockets.serve(handle_client, "0.0.0.0", PORT):
+        print(f"[server] listening on ws://0.0.0.0:{PORT}/sendspin", flush=True)
+        await asyncio.sleep(STREAM_DURATION_SECS + 30)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

This is a draft checkpoint PR for experimental Dante TX bit-depth work.

The goal was to make the bridge configurable for Dante TX bit depth instead of implicitly treating `24-bit` as fixed everywhere.

This branch adds:
- `--dante-bit-depth {16,24,32}` to `spin2dante` (default `24`)
- matching Home Assistant add-on configuration support
- Sendspin format advertisement derived from the selected Dante TX depth
- `32-bit` PCM decode support in the bridge
- an experimental `make test-32` smoke test path

This is intentionally a **draft** because the core config plumbing is in place, but the `32-bit` smoke test is still not passing and the full 32-bit story is not proven yet.

## What is implemented

### Bridge CLI and config

Added a new CLI flag:
- `--dante-bit-depth 16|24|32`

Behavior:
- default is `24`
- the selected value is used to configure both Inferno settings:
  - `BITS_PER_SAMPLE`
  - `TX_SOURCE_BIT_DEPTH`

At the bridge layer, the current design assumption is:
- Dante TX bit depth and Inferno TX source bit depth should stay the same
- if we ever want source-depth and TX-depth to diverge intentionally, that should be a separate design later rather than implicit behavior

### Sendspin format advertisement

The bridge now advertises supported Sendspin PCM bit depths based on the chosen Dante TX depth:
- `--dante-bit-depth 32` -> advertise `32, 24, 16`
- `--dante-bit-depth 24` -> advertise `24, 16`
- `--dante-bit-depth 16` -> advertise `16`

The bridge also validates incoming stream bit depth against that policy.

### PCM decode

The bridge decode path now accepts `16-bit`, `24-bit`, and `32-bit` PCM according to the selected configuration.

### Home Assistant add-on

The HA add-on config now exposes per-bridge `dante_bit_depth` and passes it through to the binary.

### Docs

`README.md`, `DESIGN.md`, `TESTING.md`, and add-on docs were updated to describe the new option and current state.

## Inferno dependency

This work depends on a separate Inferno branch in my fork:
- repo: `salanki/inferno`
- branch: `feat/dante-bit-depth`
- compare: https://github.com/salanki/inferno/compare/spin2dante-owned-buffer...feat/dante-bit-depth

That branch adds the missing Inferno-side settings support for actual Dante TX `BITS_PER_SAMPLE`.

Why that was needed:
- `TX_SOURCE_BIT_DEPTH` already existed in Inferno, but it only affected dithering behavior
- the actual Dante TX `bits_per_sample` was still effectively fixed in Inferno settings
- so without the Inferno change, a bridge-side `--dante-bit-depth` flag would have been only partially real

I am intentionally keeping that Inferno work separate for now so we do not lose it, but also do not force it into this repo PR.

## What is working

The configuration/plumbing side appears solid:
- the bridge starts with the requested Dante bit depth
- the add-on passes the new option through
- the bridge advertises the expected Sendspin formats
- the bridge accepts `32-bit` PCM streams and logs `bits=32` on stream start

## What is not finished

### `make test-32` is still failing

I added an experimental 32-bit single-stream smoke test:
- `test/docker-compose.32.yml`
- `test/sendspin_source_32/server.py`
- `make test-32`

This test currently fails overlap verification.

The original test failures turned out to include several harness problems, and I fixed a number of those:
- the custom 32-bit source now waits for the test to create Dante subscriptions before streaming
- it avoids replaying the stream on reconnect
- it now responds to `client/time` with `server/time`
- it uses a monotonic server clock base for chunk timestamps
- it waits for a few successful time-sync exchanges before starting the stream

Even after those fixes, the captured output still does not bit-match the generated 32-bit reference.

### Current best understanding of where we are stuck

At this point the remaining failure does **not** look like a simple "forgot to wire the bit-depth flag" bug.

The likely problem is still in one of these areas:
1. the custom 32-bit websocket test server is still not faithful enough to real Sendspin server behavior
2. the bridge scheduler is not reaching a stable anchor/sync state against this synthetic 32-bit source
3. the reference/capture model for the 32-bit path is still missing some detail
4. less likely, there is a real issue in the 32-bit audio path itself

I do **not** think the current failing `test-32` is strong enough evidence to claim that 32-bit Dante TX is broken. I think it is still at least as plausible that the synthetic test source is insufficiently accurate.

## Why I am stopping here

Stepping back, `32-bit` Dante TX is not an urgent product requirement right now, and Dante `24-bit` is the practical/common path.

So this draft PR is mainly a checkpoint so we do not lose:
- the CLI/add-on/docs/config work
- the bridge-side decode/advertisement changes
- the thinking and harness work around the experimental 32-bit path

## Suggested next steps if/when we pick this up again

1. Decide whether we actually want to ship/configure `16/24/32` now, or keep the UI/docs simpler and defer `32`.
2. If we continue the 32-bit work, replace the ad-hoc websocket source with a more faithful Sendspin test source, ideally reusing more of the real protocol behavior instead of emulating only the minimum needed messages.
3. Instrument the bridge during `test-32` to confirm whether it ever reaches a stable scheduler anchor against the synthetic source.
4. Verify the exact capture-domain reference model for the 32-bit path end to end.
5. Only after that, decide whether this branch should be split into:
   - a safe `16/24` config PR
   - and a separate future `32-bit` PR

## Files of interest

Bridge/config/docs:
- `src/main.rs`
- `src/bridge.rs`
- `Cargo.toml`
- `DESIGN.md`
- `TESTING.md`
- `README.md`

HA add-on:
- `addons/spin2dante/config.yaml`
- `addons/spin2dante/run.sh`
- `addons/spin2dante/DOCS.md`

Experimental 32-bit test harness:
- `test/docker-compose.32.yml`
- `test/sendspin_source_32/server.py`
- `test/control_and_test/control_and_test.sh`

## Notes

This PR is a handoff/checkpoint, not a merge recommendation in its current form.
