### PR TITLE
Reduce CPU contention: env-configurable tokio workers + real-time statime

### DIFF
--- a/addons/spin2dante/CHANGELOG.md
+++ b/addons/spin2dante/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## sha-dfa841f — 2026-06-20
+
+### Changed
+- Bridge processes now cap their Tokio runtime to 2 worker threads by default (previously sized to the host CPU count). With one process per bridge this removes heavy thread oversubscription on the audio-bridge node (e.g. 19 bridges × 8 → ~152 worker threads on 8 cores), the overload root cause behind systemic multi-zone `flows_tx` "media clock jumped" dropouts. The timing-critical DANTE TX runs on inferno's own real-time thread, not the Tokio pool, so a small pool is sufficient. Overridable via the `SPIN2DANTE_WORKER_THREADS` environment variable.
+
 ## sha-c341162 — 2026-05-17
 
 ### Fixed

--- a/addons/spin2dante/config.yaml
+++ b/addons/spin2dante/config.yaml
@@ -1,5 +1,5 @@
 name: "spin2dante"
-version: "sha-c341162"
+version: "sha-dfa841f"
 slug: spin2dante
 description: >-
   Bit-perfect bridge of one or more Sendspin audio streams to Audinate DANTE channels.

--- a/addons/statime/Dockerfile
+++ b/addons/statime/Dockerfile
@@ -24,7 +24,7 @@ LABEL \
   org.opencontainers.image.source="https://github.com/salanki/spin2dante" \
   org.opencontainers.image.description="Home Assistant add-on for exporting a PTP clock socket for spin2dante and inferno-based Dante tools." \
   org.opencontainers.image.licenses="GPL-3.0-or-later OR AGPL-3.0-or-later"
-RUN apk add --no-cache libgcc iproute2
+RUN apk add --no-cache libgcc iproute2 util-linux
 COPY --from=builder /build/target/release/statime /usr/local/bin/statime
 COPY statime/statime-docker.toml /etc/statime.toml.template
 COPY addons/statime/run.sh /run.sh

--- a/addons/statime/config.yaml
+++ b/addons/statime/config.yaml
@@ -9,6 +9,10 @@ startup: system
 boot: auto
 init: false
 host_network: true
+# Grant CAP_SYS_NICE + rtprio ulimit so run.sh can put the PTP daemon on a
+# real-time (SCHED_FIFO) priority. Under CPU contention the clock daemon must not
+# be starved by the audio TX threads — see run.sh (chrt).
+realtime: true
 arch:
   - aarch64
   - amd64

--- a/addons/statime/run.sh
+++ b/addons/statime/run.sh
@@ -24,4 +24,18 @@ bashio::log.info "Starting statime"
 bashio::log.info "Interface: $PTP_INTERFACE"
 bashio::log.info "Clock path: $CLOCK_PATH"
 
-exec /usr/local/bin/statime -c /etc/statime.toml
+# Run the PTP daemon at a real-time (SCHED_FIFO) priority so it isn't starved by
+# the normal-priority load on the audio-bridge node (the clock is the most
+# contention-sensitive piece — a starved daemon lets the media clock jump, which
+# shows up as inferno flows_tx "media clock jumped, dropout occurs" across all
+# zones at once). Priority 80 sits just below the audio TX threads (FF 81) on
+# purpose, so this can't preempt audio. Requires `realtime: true` in config.yaml
+# (CAP_SYS_NICE + rtprio); fall back to normal scheduling if chrt is unavailable
+# or lacks permission.
+if command -v chrt >/dev/null 2>&1 && chrt -f 80 true 2>/dev/null; then
+    bashio::log.info "Scheduling statime at SCHED_FIFO priority 80"
+    exec chrt -f 80 /usr/local/bin/statime -c /etc/statime.toml
+else
+    bashio::log.warning "chrt unavailable or no rtprio permission; starting statime at normal priority"
+    exec /usr/local/bin/statime -c /etc/statime.toml
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,13 @@ fn main() {
     // timing-critical DANTE TX runs on inferno's own SCHED_FIFO thread, not the tokio
     // pool, so a small pool is plenty. Configurable via SPIN2DANTE_WORKER_THREADS
     // (default 2).
+    //
+    // Why 2 and not 1: this binary spawns no tasks of its own (bridge::run is a single
+    // select! loop), but the sendspin transport runs its own background task that drives
+    // the WebSocket and feeds the message/audio channels. With a single worker that task
+    // shares a thread with the bridge loop, so an inline audio chunk decode+ring-write
+    // would stall the socket drain and back up the kernel receive buffer. Two workers let
+    // the transport keep draining while a chunk is processed. More than 2 just sits idle.
     let worker_threads = env::var("SPIN2DANTE_WORKER_THREADS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,8 +130,27 @@ struct Args {
     report_dante_subscriber: bool,
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    // Tokio defaults the multi-thread runtime to num_cpus worker threads (8 on the
+    // audio-bridge VM). With one spin2dante process per bridge that is heavy
+    // oversubscription (e.g. 19 bridges x 8 = ~152 worker threads on 8 cores). The
+    // timing-critical DANTE TX runs on inferno's own SCHED_FIFO thread, not the tokio
+    // pool, so a small pool is plenty. Configurable via SPIN2DANTE_WORKER_THREADS
+    // (default 2).
+    let worker_threads = env::var("SPIN2DANTE_WORKER_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(2);
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime")
+        .block_on(async_main());
+}
+
+async fn async_main() {
     let logenv = env_logger::Env::default().default_filter_or("info");
     env_logger::init_from_env(logenv);
 


### PR DESCRIPTION
## Reduce CPU contention on the audio-bridge node

Two low-risk changes that target the **overload root cause** behind the 2026-06-20 dropout storm (systemic `inferno flows_tx` "media clock jumped, dropout occurs" hitting many zones at once). Refs #12.

### Evidence (live, VM 100, 8 vCPUs)
Inspected the running threads via the guest agent:
- Each spin2dante `flows TX` thread is **already `SCHED_FIFO` prio 81** — RT is handled.
- **`statime` (PTP daemon) was entirely `TS` (normal)** — main + all tokio workers. It was the lowest-priority thing on the box, behind ~152 normal-priority tokio workers and the audio TX threads.
- Each bridge's tokio runtime defaulted to **`num_cpus` = 8 workers**; with ~19 bridge processes that's **~152 worker threads on 8 cores**.

A starved PTP daemon lets the shared media clock drift/jump → every FF-81 TX thread reports a dropout simultaneously. That matches the systemic, multi-zone, every-2–3-min signature.

### Changes

**1. spin2dante: cap tokio worker threads (env-configurable, default 2)** — `src/main.rs`
- Replaced bare `#[tokio::main]` (which sizes the pool to `num_cpus`) with an explicit runtime built from **`SPIN2DANTE_WORKER_THREADS`** (default **2**).
- Rationale: the timing-critical DANTE TX runs on inferno's own SCHED_FIFO thread, *not* the tokio pool. Per-bridge async work (one Sendspin WS stream + decode + timers) needs ~a fraction of a core. 19 × 2 = ~38 threads instead of ~152.
- Tunable at runtime without rebuilding (e.g. `SPIN2DANTE_WORKER_THREADS=1` or `=4`).

**2. statime add-on: run the PTP daemon real-time** — `addons/statime/{config.yaml,Dockerfile,run.sh}`
- `config.yaml`: add **`realtime: true`** (grants `CAP_SYS_NICE` + rtprio ulimit; required for `chrt -f`).
- `Dockerfile`: add **`util-linux`** (HA base busybox has no `chrt` applet).
- `run.sh`: `exec chrt -f 80 /usr/local/bin/statime …`, with a graceful fallback to normal scheduling if `chrt` is missing or lacks permission.
- **Priority 80 is deliberately *below* the audio TX threads (FF 81)** — it lifts the clock above all the normal-priority (`TS`) noise without ever preempting audio. The TX threads are short/periodic, so statime still gets scheduled in the gaps.

### Not changed (intentionally)
- The standalone docker-compose variant (`statime/entrypoint.sh`, `statime/Dockerfile`) is untouched — for that path, RT also needs `--cap-add=SYS_NICE` + `--ulimit rtprio` on the container, which lives in compose, not the image. Easy to add later if that path is used.
- No `inferno_aoip` / statime *source* changes — `chrt` wraps the unmodified binary; tokio change is local.

### Testing notes
- Build the spin2dante + statime add-on images from this branch on the test instance and redeploy.
- Verify scheduling on the host: `ps -eLo pid,tid,cls,rtprio,comm | grep -iE 'statime|flows'` → statime threads should show `FF 80`, TX threads `FF 81`.
- Confirm spin2dante worker count dropped: each process should now show ~2 `tokio-rt-worker` threads instead of 8 (`SPIN2DANTE_WORKER_THREADS` overrides).
- Re-run a 20-zone whole-house group and watch for the `flows_tx` "tx lag / media clock jumped" ERRORs + statime offset stability under load.
